### PR TITLE
Improve HTML cleaning and text extraction. Closes #10

### DIFF
--- a/src/test/java/org/jboss/elasticsearch/tools/content/StripHtmlPreprocessorTest.java
+++ b/src/test/java/org/jboss/elasticsearch/tools/content/StripHtmlPreprocessorTest.java
@@ -155,7 +155,7 @@ public class StripHtmlPreprocessorTest {
 					.put(tested.fieldSource,
 							"<b>aa<b>bb<br>cdgh &lt;<div>text in div</div>\n &amp; then\n invalid <p> paragraph <pre>test\npre &amp;</pre>");
 			tested.preprocessData(values);
-			Assert.assertEquals("aabb cdgh < text in div & then invalid paragraph test\npre &",
+			Assert.assertEquals("aa bb cdgh < text in div & then invalid paragraph test pre &",
 					(String) values.get(tested.fieldTarget));
 		}
 
@@ -170,7 +170,7 @@ public class StripHtmlPreprocessorTest {
 					.put("source",
 							"<b>aa<b>bb<br>cdgh &lt;<div>text in div</div>\n &amp; then\n invalid <p> paragraph <pre>test\npre &amp;</pre>");
 			tested.preprocessData(values);
-			Assert.assertEquals("aabb cdgh < text in div & then invalid paragraph test\npre &",
+			Assert.assertEquals("aa bb cdgh < text in div & then invalid paragraph test pre &",
 					(String) values2.get("target"));
 		}
 	}


### PR DESCRIPTION
- We are explicitly using Jsoup.clean(html, Whitelist.relaxed()) to sanity and clean the HTML.
- We traverse the Element tree when extracting the text and we append extra white space after each node content to prevent connecting the end word with the first one from the following node.
- Breaking change: removal of formatting from <pre/> blocks.
