### PR TITLE
Corrected SimpleDateFormat's date format to be fully ISO 8601 compatible. Closes #35

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ For Elasticsearch 1.x series and java 1.7
 	<dependency>
 	  <groupId>org.jboss.elasticsearch</groupId>
 	  <artifactId>structured-content-tools</artifactId>
-	  <version>1.3.7</version>
+	  <version>1.3.8</version>
 	</dependency>
 
 For Elasticsearch 0.90.5 series and java 1.6

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 		<modelVersion>4.0.0</modelVersion>
 		<groupId>org.jboss.elasticsearch</groupId>
 		<artifactId>structured-content-tools</artifactId>
-		<version>1.3.7</version>
+		<version>1.3.8</version>
 		<packaging>jar</packaging>
 		<description>Tools to manipulate structured content</description>
 		<inceptionYear>2012</inceptionYear>

--- a/src/main/java/org/jboss/elasticsearch/tools/content/ValueUtils.java
+++ b/src/main/java/org/jboss/elasticsearch/tools/content/ValueUtils.java
@@ -178,7 +178,7 @@ public class ValueUtils {
 		return finalContent.toString();
 	}
 
-	protected static final SimpleDateFormat ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SZ");
+	protected static final SimpleDateFormat ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXX");
 	static {
 		ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
 	}

--- a/src/test/java/org/jboss/elasticsearch/tools/content/LongToTimestampValuePreprocessorTest.java
+++ b/src/test/java/org/jboss/elasticsearch/tools/content/LongToTimestampValuePreprocessorTest.java
@@ -165,7 +165,7 @@ public class LongToTimestampValuePreprocessorTest {
 			Map<String, Object> values = new HashMap<String, Object>();
 			values.put(tested.fieldSource, "100");
 			tested.preprocessData(values, null);
-			Assert.assertEquals("1970-01-01T00:00:00.100+0000", values.get(tested.fieldTarget));
+			Assert.assertEquals("1970-01-01T00:00:00.100Z", values.get(tested.fieldTarget));
 		}
 
 		// *** Number values handling
@@ -175,7 +175,7 @@ public class LongToTimestampValuePreprocessorTest {
 			Map<String, Object> values = new HashMap<String, Object>();
 			values.put(tested.fieldSource, new Integer(10));
 			tested.preprocessData(values, null);
-			Assert.assertEquals("1970-01-01T00:00:00.10+0000", values.get(tested.fieldTarget));
+			Assert.assertEquals("1970-01-01T00:00:00.010Z", values.get(tested.fieldTarget));
 		}
 
 		// case - Long, rewrite source
@@ -184,7 +184,7 @@ public class LongToTimestampValuePreprocessorTest {
 			Map<String, Object> values = new HashMap<String, Object>();
 			values.put(tested.fieldSource, new Long(510));
 			tested.preprocessData(values, null);
-			Assert.assertEquals("1970-01-01T00:00:00.510+0000", values.get(tested.fieldTarget));
+			Assert.assertEquals("1970-01-01T00:00:00.510Z", values.get(tested.fieldTarget));
 		}
 	}
 
@@ -213,12 +213,12 @@ public class LongToTimestampValuePreprocessorTest {
 
 			tested.preprocessData(values, null);
 
-			assertDataStructure(values.get("author"), "10", "1970-01-01T00:00:00.10+0000");
-			assertDataStructure(values.get("editor"), new Long("150"), "1970-01-01T00:00:00.150+0000");
+			assertDataStructure(values.get("author"), "10", "1970-01-01T00:00:00.010Z");
+			assertDataStructure(values.get("editor"), new Long("150"), "1970-01-01T00:00:00.150Z");
 
 			Assert.assertEquals(2, comments.size());
-			assertDataStructure(comment1, "250", "1970-01-01T00:00:00.250+0000");
-			assertDataStructure(comment2, "4521", "1970-01-01T00:00:04.521+0000");
+			assertDataStructure(comment1, "250", "1970-01-01T00:00:00.250Z");
+			assertDataStructure(comment2, "4521", "1970-01-01T00:00:04.521Z");
 		}
 	}
 

--- a/src/test/java/org/jboss/elasticsearch/tools/content/ValueUtilsTest.java
+++ b/src/test/java/org/jboss/elasticsearch/tools/content/ValueUtilsTest.java
@@ -6,6 +6,7 @@
 package org.jboss.elasticsearch.tools.content;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,10 +147,13 @@ public class ValueUtilsTest {
 	@Test
 	public void formatISODateTime() {
 		Assert.assertNull(ValueUtils.formatISODateTime(null));
+        Assert.assertEquals( ISODateTimeFormat.dateTime().withZoneUTC().print(1344945600000L),
+                ValueUtils.formatISODateTime(new Date(1344945600000L))); 
 		Assert.assertEquals(
-				"2012-08-14T12:00:00.0+0000",
+				"2012-08-14T12:00:00.000Z",
 				ValueUtils.formatISODateTime(ISODateTimeFormat.dateTimeParser().parseDateTime("2012-08-14T13:00:00.0+0100")
 						.toDate()));
+		
 	}
 
 }


### PR DESCRIPTION
... and also act in the same way as Joda Time libary used in other places. Additionally raised version number in the main pom.xml.
